### PR TITLE
Use Current Branch

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -28,4 +28,4 @@ git checkout $branch
 
 echo "Running release-it"
 # $1 is the release type major, minor or patch
-DEBUG=release-it:* release-it ${RELEASE_TYPE} --preRelease=staging --ci --no-npm
+DEBUG=release-it:* release-it $RELEASE_TYPE --preRelease=staging --ci --no-npm

--- a/run.sh
+++ b/run.sh
@@ -19,11 +19,6 @@ git clone https://github.com/${REPO}.git
 echo "Adding remote for repo ${REPO}"
 git remote add origin https://github.com/${REPO}.git
 
-echo "Checking out Staging branch"
-git fetch
-git checkout origin/staging
-git checkout -b staging
-
 echo "Running release-it"
 # $1 is the release type major, minor or patch
 DEBUG=release-it:* release-it ${RELEASE_TYPE} --preRelease=staging --ci --no-npm

--- a/run.sh
+++ b/run.sh
@@ -19,10 +19,11 @@ git clone https://github.com/${REPO}.git
 echo "Adding remote for repo ${REPO}"
 git remote add origin https://github.com/${REPO}.git
 
-echo "Checking out Master branch"
+branch=${GITHUB_REF#refs/heads/}
+echo "Checking out $branch branch"
 git fetch
-git checkout origin/master
-git checkout master
+git checkout origin/$branch
+git checkout $branch
 
 
 echo "Running release-it"

--- a/run.sh
+++ b/run.sh
@@ -19,6 +19,12 @@ git clone https://github.com/${REPO}.git
 echo "Adding remote for repo ${REPO}"
 git remote add origin https://github.com/${REPO}.git
 
+echo "Checking out Master branch"
+git fetch
+git checkout origin/master
+git checkout master
+
+
 echo "Running release-it"
 # $1 is the release type major, minor or patch
 DEBUG=release-it:* release-it ${RELEASE_TYPE} --preRelease=staging --ci --no-npm


### PR DESCRIPTION
In public-api repo it works better for us to create a release candidate on master, so I changed this to use current branch